### PR TITLE
tty workaround (side benefit: cleaner RUN scripts)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && dpkg-reconfigure locales \
     && update-locale LANG=${__LANG} LANGUAGE=${__LANGUAGE} LC_ALL=${__LC_ALL} \
     && unset DEBIAN_FRONTEND \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /usr/share/terminfo/d \
+    && ln -s /lib/terminfo/d/dumb /usr/share/terminfo/d/dumb
 ENV LANG=${__LANG}
 SHELL ["/bin/sh", "-c"]
 
@@ -93,6 +95,7 @@ ARG NPM_VERSION
 ARG NVM_VERSION
 SHELL ["/bin/bash", "-c"]
 RUN adduser --disabled-password --shell /bin/bash --gecos "" embark \
+    && usermod -a -G tty embark \
     && mkdir -p /dapp \
     && chown embark:embark /dapp \
     && curl -fsSLO --compressed "https://bootstrap.pypa.io/get-pip.py" \

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ echo $1
 # a comment
 echo $2
 echo $3
-eval echo \\\$\$3
+eval echo \$$3
 # another comment
 ```
 Invoke with:

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ Many aspects of `run_embark`'s behavior can be overridden with environment
 variables, and that approach can be (optionally) combined with `docker build`.
 
 ``` shell
-export EMBARK_DOCKER_IMAGE=statusim/embark
-export EMBARK_DOCKER_TAG=develop
-export EMBARK_DOCKERFILE='https://github.com/embark-framework/embark-docker.git#master'
-export EMBARK_VERSION='embark-framework/embark#develop'
-export NODE_VERSION=10.7.0
-export RUNNER='https://raw.githubusercontent.com/embark-framework/embark-docker/master/run.sh'
+EMBARK_DOCKER_IMAGE=statusim/embark
+EMBARK_DOCKER_TAG=develop
+EMBARK_DOCKERFILE='https://github.com/embark-framework/embark-docker.git#master'
+EMBARK_VERSION='embark-framework/embark#develop'
+NODE_VERSION=10.7.0
+RUNNER='https://raw.githubusercontent.com/embark-framework/embark-docker/master/run.sh'
 
 docker build \
        --build-arg EMBARK_VERSION=$EMBARK_VERSION \

--- a/env/.bash_env
+++ b/env/.bash_env
@@ -126,4 +126,6 @@ __versions_export () {
 }
 export -f __versions_export
 
-nac default
+if [[ ! -v NODE_VIRTUAL_ENV ]]; then
+    nac default
+fi

--- a/env/docker-entrypoint.sh
+++ b/env/docker-entrypoint.sh
@@ -3,4 +3,5 @@
 export BASH_ENV=/home/embark/.bash_env
 
 chmod a+w /dev/std*
+chmod g+r /dev/pts/0
 exec su-exec embark user-entrypoint.sh "$@"

--- a/run.sh
+++ b/run.sh
@@ -141,17 +141,21 @@ run_embark () {
         fi
 
         local run_script=$(< "$EMBARK_DOCKER_RUN")
-# do not add indentation to lines below
-        run_script="exec bash -s ${cmd[@]} << 'SCRIPT'
-td=\$(mktemp -d)
-cat << 'RUN' > \$td/run_script
-$run_script
-RUN
-chmod +x \$td/run_script
-exec \$td/run_script \$@
-SCRIPT
-"
-# do not add indentation to lines above
+        # do not alter indentation, tabs in lines below
+        run_script=$(cat <<- RUN_SCRIPT
+	exec bash -${i_flag}s \$(tty) ${cmd[@]} << 'SCRIPT'
+	__tty=\$1
+	shift
+	td=\$(mktemp -d)
+	cat << 'RUN' > \$td/run_script
+	$run_script
+	RUN
+	chmod +x \$td/run_script
+	exec \$td/run_script \$@ < \$__tty
+	SCRIPT
+	RUN_SCRIPT
+        )
+        # do not alter indentation, tabs in lines above
         cmd=( "bash" "-${i_flag}c" "$run_script" )
     fi
 

--- a/run.sh
+++ b/run.sh
@@ -143,16 +143,16 @@ run_embark () {
         local run_script=$(< "$EMBARK_DOCKER_RUN")
         # do not alter indentation, tabs in lines below
         run_script=$(cat <<- RUN_SCRIPT
-	exec bash -${i_flag}s \$(tty) ${cmd[@]} << 'SCRIPT'
+	exec bash -${i_flag}s \$(tty) ${cmd[@]} << 'RUN'
 	__tty=\$1
 	shift
-	td=\$(mktemp -d)
-	cat << 'RUN' > \$td/run_script
+	script=\$(mktemp)
+	cat << 'SCRIPT' > \$script
 	$run_script
-	RUN
-	chmod +x \$td/run_script
-	exec \$td/run_script \$@ < \$__tty
 	SCRIPT
+	chmod +x \$script
+	exec \$script \$@ < \$__tty
+	RUN
 	RUN_SCRIPT
         )
         # do not alter indentation, tabs in lines above

--- a/run.sh
+++ b/run.sh
@@ -146,7 +146,7 @@ run_embark () {
 	exec bash -${i_flag}s \$(tty) ${cmd[@]} << 'RUN'
 	__tty=\$1
 	shift
-	script=\$(mktemp)
+	script=/tmp/run_embark_script
 	cat << 'SCRIPT' > \$script
 	$run_script
 	SCRIPT


### PR DESCRIPTION
While working on the [demo script](https://github.com/embark-framework/embark/blob/features/global-local-cmd-shim/test/cli_shim/demo.sh) for the global/local cli shim (shim and demo are still WIP, but almost done), I found I needed to make some adjustments to the embark-docker repo.

There have been no changes in basic functionality, but these revisions ensure the terminal device allocated by the container behaves as one would expect when doing advanced scripting. Also, this has a side-benefit of `EMBARK_DOCKER_RUN` scripts being a little cleaner when one is working with escaped dollar signs.